### PR TITLE
Inclusion of nsp to verify vulnerabilities before we publish the npm modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
   "bugs": {
     "url": "https://issues.jboss.org/browse/AGSMPLPUSH"
   },
+  "devDependencies": {
+    "nsp": "*"
+  },
+  "scripts": {
+    "prepublish": "nsp audit-package"
+  },
   "licenses": [
     {
       "type": "Apache-2.0",


### PR DESCRIPTION
This PR adds nsp (https://github.com/nodesecurity/nsp) responsible to check vulnerabilities against nodesecurity project.
